### PR TITLE
add cache for maven dependencies

### DIFF
--- a/.github/workflows/temurin-updater.yml
+++ b/.github/workflows/temurin-updater.yml
@@ -23,10 +23,11 @@ jobs:
           ref: marketplace
           path: api
 
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'temurin'
+          cache: 'maven'
         
       - name: Build API
         run: ./mvnw -DskipTests --batch-mode clean install -Padoptium

--- a/.github/workflows/validate-data.yml
+++ b/.github/workflows/validate-data.yml
@@ -24,10 +24,11 @@ jobs:
           ref: marketplace
           path: api
 
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'temurin'
+          cache: 'maven'
 
       - name: Build API
         run: ./mvnw -DskipTests --batch-mode clean install -Padoptium


### PR DESCRIPTION
cache is showing as being created now:

```
Cache Size: ~355 MB (371899184 B)
Cache saved successfully
Cache saved with the key: setup-java-Linux-maven-95[4](https://github.com/adoptium/marketplace-data/runs/6571639090?check_suite_focus=true#step:12:4)2488de[5](https://github.com/adoptium/marketplace-data/runs/6571639090?check_suite_focus=true#step:12:5)e75919ffb927170869c7c5adef8d1d6918d6a12e4bc6bdf7ad886a
```