### PR TITLE
Revert token restriction as it breaks job

### DIFF
--- a/.github/workflows/temurin-updater.yml
+++ b/.github/workflows/temurin-updater.yml
@@ -8,9 +8,6 @@ on:
     - cron: "0 0 * * *"
   workflow_dispatch:
 
-permissions:
-  contents: read
-
 jobs:
   update:
     if: github.repository_owner == 'adoptium'


### PR DESCRIPTION
This change broke the code of conduct sync job so I’m reverting it