### PR TITLE
Check if the file is new or if exists to fix updater action

### DIFF
--- a/.github/workflows/temurin-updater.yml
+++ b/.github/workflows/temurin-updater.yml
@@ -58,7 +58,10 @@ jobs:
             FULL_DIFF=$(git status | egrep ".*\.json$")
             for file in **/*.sign; do
               JSON_PATH=$(echo $file | sed -e "s/.sha256.sign//")
-              if [ ! -n "$(echo "$FULL_DIFF" | grep "$JSON_PATH")" ]; then
+              EXISTS=$(git ls-tree -r HEAD --name-only |grep $file)
+              if [ -z "$EXISTS" ]; then 
+                echo "Add new file: $file"
+              else
                 git checkout main "$file"
               fi
             done


### PR DESCRIPTION
This PR is to fix the fail in the Action

error: pathspec '21/index.json.sha256.sign' did not match any file(s) known to git

![image](https://github.com/adoptium/marketplace-data/assets/3774556/4031da96-9b85-43a9-8940-309c6516c2a1)

