### PR TITLE
bump PR generator action

### DIFF
--- a/.github/workflows/temurin-updater.yml
+++ b/.github/workflows/temurin-updater.yml
@@ -68,7 +68,7 @@ jobs:
           fi
         id: diff
 
-      - uses: gr2m/create-or-update-pull-request-action@77596e3166f328b24613f7082ab30bf2d93079d5 # v1
+      - uses: gr2m/create-or-update-pull-request-action@73b5860c078571041abd2e438b8377a24dbc2465 # v1
         env:
           GITHUB_TOKEN: ${{ secrets.ADOPTIUM_TEMURIN_BOT_TOKEN }}
         if: steps.diff.outputs.DIFF != 0


### PR DESCRIPTION
fixes the following warnings:


update_dockerfileNode.js 16 actions are deprecated. Please update the following actions to use Node.js 20: gr2m/create-or-update-pull-request-action@dc1726cbf4dd3ce766af4ec29cfb660e0125e8ee. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.Show more
--
update_dockerfileThe `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

[update_dockerfile](https://github.com/adoptium/containers/actions/runs/8438259881/job/23110015531)
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: gr2m/create-or-update-pull-request-action@dc1726cbf4dd3ce766af4ec29cfb660e0125e8ee. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
[update_dockerfile](https://github.com/adoptium/containers/actions/runs/8438259881/job/23110015531#step:6:21)
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/